### PR TITLE
Disable log_sync test that is currently failing.

### DIFF
--- a/lib/log_synchronizer/synchronizer_test.py
+++ b/lib/log_synchronizer/synchronizer_test.py
@@ -195,6 +195,7 @@ class TestSynchronizer(unittest.TestCase):
       self.assertEqual(uploaded, [])
       self.assertTrue(mock_log.assert_any_call)
 
+  @unittest.skip('Test failing, seems to be accessing real GS bucket.')
   def testUploadGoodTiming(self):
     def AssertRemoteFiles():
       gs_api = gsutil.GsutilApi()


### PR DESCRIPTION
It seems that this test tries to access the real gs://makani bucket.