### PR TITLE
Implemented GitHub Actions support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,26 @@
+name: Ubuntu
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+    
+    - name: build
+      run: |
+        ./lib/scripts/install/install_packages.sh
+        source ~/.bashrc
+        cd ${MAKANI_HOME}
+        bbuild_x86
+        btest_all

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,4 +1,4 @@
-name: Ubuntu
+name: Docker
 
 on:
   push:
@@ -18,9 +18,4 @@ jobs:
       uses: actions/checkout@v2
     
     - name: build
-      run: |
-        ./lib/scripts/install/install_packages.sh
-        source ~/.bashrc
-        cd ${MAKANI_HOME}
-        bbuild_x86
-        btest_all
+      run: ./docker_build.sh

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Makani
 
+![Docker](https://github.com/google/makani/workflows/Docker/badge.svg)
+
 Makani was a project to develop a commercial-scale airborne wind turbine, culminating in
 a flight test of the Makani M600 off the coast of Norway. All Makani software has now been
 open-sourced. This repository contains the working Makani flight simulator, controller (autopilot),


### PR DESCRIPTION
### GitHub Actions

Implemented a CI for building the Docker image.

A successful run can be seen [here](https://github.com/leozz37/makani/actions/runs/321032819).

![Docker](https://github.com/leozz37/makani/workflows/Docker/badge.svg)